### PR TITLE
feat: remove icon and indicator from widget

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -101,10 +101,6 @@ context("Form", () => {
 		cy.get("@email_input2").type(valid_email, { waitForAnimations: false });
 
 		cy.get("@row1").click();
-		cy.get("@email_input1").should(($div) => {
-			const style = window.getComputedStyle($div[0]);
-			expect(style.backgroundColor).to.equal(expectBackgroundColor);
-		});
 		cy.get("@email_input1").should("have.class", "invalid");
 
 		cy.get("@row2").click();

--- a/cypress/integration/list_paging.js
+++ b/cypress/integration/list_paging.js
@@ -29,7 +29,7 @@ context("List Paging", () => {
 		cy.get(".list-paging-area .list-count").should("contain.text", "300 of");
 
 		// check if refresh works after load more
-		cy.get('.page-head .standard-actions [data-original-title="Refresh"]').click();
+		cy.get('.page-head .standard-actions [data-original-title="Reload List"]').click();
 		cy.get(".list-paging-area .list-count").should("contain.text", "300 of");
 
 		cy.get('.list-paging-area .btn-group .btn-paging[data-value="500"]').click();

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -14,7 +14,7 @@ context("List View", () => {
 		cy.go_to_list("ToDo");
 		cy.clear_filters();
 		cy.get(".list-header-subject > .list-subject > .list-check-all").click();
-		cy.get("button[data-original-title='Refresh']").click();
+		cy.get("button[data-original-title='Reload List']").click();
 		cy.get(".list-row-container .list-row-checkbox:checked").should("be.visible");
 	});
 

--- a/frappe/public/js/frappe/widgets/base_widget.js
+++ b/frappe/public/js/frappe/widgets/base_widget.js
@@ -98,15 +98,11 @@ export default class Widget {
 		let base = this.title || this.label || this.name;
 		let title = max_chars ? frappe.ellipsis(base, max_chars) : base;
 
-		if (this.icon) {
-			let icon = frappe.utils.icon(this.icon, "sm");
-			this.title_field[0].innerHTML = `${icon} <span class="ellipsis" title="${title}">${title}</span>`;
-		} else {
-			this.title_field[0].innerHTML = `<span class="ellipsis" title="${title}">${title}</span>`;
-			if (max_chars) {
-				this.title_field[0].setAttribute("title", this.title || this.label);
-			}
+		this.title_field[0].innerHTML = `<span class="ellipsis" title="${title}">${title}</span>`;
+		if (max_chars) {
+			this.title_field[0].setAttribute("title", this.title || this.label);
 		}
+
 		this.subtitle && this.subtitle_field.html(this.subtitle);
 	}
 

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -31,16 +31,6 @@ export default class LinksWidget extends Widget {
 			return is_link_disabled(item) ? "disabled-link" : "";
 		};
 
-		const get_indicator_color = (item) => {
-			if (item.open_count) {
-				return "red";
-			}
-			if (item.onboard) {
-				return item.count ? "blue" : "yellow";
-			}
-			return "gray";
-		};
-
 		const get_link_for_item = (item) => {
 			if (is_link_disabled(item)) {
 				return `<span class="link-content ellipsis disabled-link">${
@@ -86,7 +76,6 @@ export default class LinksWidget extends Widget {
 			} ${disabled_dependent(item)}" type="${item.type}" title="${
 				item.label ? item.label : item.name
 			}">
-					<span class="indicator-pill no-margin ${get_indicator_color(item)}"></span>
 					${get_link_for_item(item)}
 			</a>`);
 		});


### PR DESCRIPTION
Can we remove these meaningless leading icons (or replace them with meaningful ones)?

### Before
![before](https://github.com/maharshivpatel/frappe/assets/14891507/0aa05710-69b4-4a5c-a4bc-731aa8f968da)

### After

![after](https://github.com/maharshivpatel/frappe/assets/14891507/3553aa38-2d40-4cb6-8567-d48f257012fa)

> Please ignore Ankush's commits – not sure why they are shown here.